### PR TITLE
OSX installation instructions

### DIFF
--- a/installation-osx.html
+++ b/installation-osx.html
@@ -1,0 +1,348 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="The Topology ToolKit">
+    <meta name="author" content="The Topology ToolKit">
+    <meta name="keywords" content="TTK, Topology ToolKit, Topological Data 
+Analysis, Visualization, Reeb graph, Reeb Space, Morse-Smale complex, contour 
+tree, persistence diagram, persistence curve, continuous scatterplot, fiber 
+surface, contour forests, jacobi set, mandatory critical points, topological 
+simplification, VTK, ParaView, Python" />
+
+    <title>TTK - the Topology ToolKit</title>
+
+    <!-- Bootstrap Core CSS -->
+    <link href="vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
+
+    <!-- Theme CSS -->
+    <link href="css/clean-blog.min.css" rel="stylesheet">
+
+    <!-- Custom Fonts -->
+    <link href="vendor/font-awesome/css/font-awesome.min.css" rel="stylesheet" type="text/css">
+    <link href='https://fonts.googleapis.com/css?family=Lora:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800' rel='stylesheet' type='text/css'>
+
+    <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
+    <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
+    <!--[if lt IE 9]>
+        <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
+        <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
+    <![endif]-->
+
+<!-- Google Analytics -->
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  
+})(window,document,'script','https://www.google-analytics.com/analytics.js','ga'
+);
+
+  ga('create', 'UA-88087813-1', 'auto');
+  ga('send', 'pageview');
+
+</script>
+<script type="text/javascript">
+
+  var _gaq = _gaq || [];
+  var pluginUrl =
+  '//www.google-analytics.com/plugins/ga/inpage_linkid.js';
+  _gaq.push(['_require', 'inpage_linkid', pluginUrl]);
+  _gaq.push(['_setAccount', 'UA-88087813-1']);
+  _gaq.push(['_trackPageview']);
+
+  (function() {
+    var ga = document.createElement('script'); ga.type =
+      'text/javascript'; ga.async = true;
+    ga.src = ('https:' == document.location.protocol ? 'https://ssl'
+      : 'http://www') + '.google-analytics.com/ga.js';
+    var s = document.getElementsByTagName('script')[0];
+    s.parentNode.insertBefore(ga, s);
+  })();
+</script>
+<!-- End Google Analytics -->
+
+</head>
+
+<body>
+
+    <!-- Navigation -->
+    <nav class="navbar navbar-default navbar-custom navbar-fixed-top">
+        <div class="container-fluid">
+            <!-- Brand and toggle get grouped for better mobile display -->
+            <div class="navbar-header page-scroll">
+                <button type="button" class="navbar-toggle" 
+data-toggle="collapse" data-target="#bs-example-navbar-collapse-1">
+                    <span class="sr-only">Toggle navigation</span>
+                    Menu <i class="fa fa-bars"></i>
+                </button>
+                <a class="navbar-brand" href="index.html">
+                TTK Home</a>
+            </div>
+
+            <!-- Collect the nav links, forms, and other content for toggling 
+-->
+            <div class="collapse navbar-collapse" 
+id="bs-example-navbar-collapse-1">
+                <ul class="nav navbar-nav navbar-right">
+                    <li>
+                        <a href="gallery.html">Gallery</a>
+                    </li>
+                    <li>
+                        <a href="downloads.html">Downloads</a>
+                    </li>
+                    <li>
+                        <a href="installation.html">Installation</a>
+                    </li>
+                    <li>
+                        <a href="tutorials.html">Tutorials</a>
+                    </li>
+                    <li>
+                        <a href="documentation.html">Documentation</a>
+                    </li>
+                    <li>
+                        <a href="contribute.html">Contribute</a>
+                    </li>
+                    <li>
+                        <a href="contact.html">Contact</a>
+                    </li>
+                </ul>
+            </div>
+            <!-- /.navbar-collapse -->
+        </div>
+        <!-- /.container -->
+    </nav>
+
+    <!-- Page Header -->
+    <!-- Set your background image for this header on the line below. -->
+    <header class="intro-header" 
+      style="background-image: url('img/morseHills.png'">
+        <div class="container">
+            <div class="row">
+                <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">
+                    <div class="page-heading">
+                        <h1>Topology ToolKit</h1>
+                        <hr class="small">
+                        <span class="subheading">OSX Installation</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </header>
+
+    <!-- Main Content -->
+    <div class="container">
+        <div class="row">
+            <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">
+  
+
+Some notes on installation for OSX, using Sierra 10.12.5.  The key differences involve how ParaView is compiled, installing certain dependencies, and setting up some of the paths for OSX.  The follow assumes that the target is to compile with OSX clang and uses homebrew for dependencies.<br>
+
+<p><h3>1. Downloads</h3>
+These instructions are identical.
+</p>
+
+
+
+<p><h3>2. Installing the dependencies</h3>
+Using homebrew, install:
+<ul>
+<li> cmake (tested with 3.8.2) </li>
+<li> qt5 (tested with 5.9.0) </li>
+<li> python (tested with 2.7.13) </li>
+<li> vtk (tested with 7.1.1_1) </li>
+</ul><br>
+
+<h4>a) Optional Dependencies</h4>
+
+Using homebrew, one can install:
+<ul>
+<li> ffmpeg (tested with 3.3.2) </li>
+<li> hdf5 (tested with 1.10.1) </li>
+<li> tbb (tested with 2017_U7) -- needed for OSPRay </li>
+<li> mpich (tested with 3.2_3) -- needed for OSPRay's execution </li>
+</ul><br>
+
+And, in addition, one can install OSPRay and it's dependencies using:
+
+<ul>
+<li>Download and unpack ospray-1.3.0.x86_64.dmg from <a href="http://www.ospray.org/getting_ospray.html">http://www.ospray.org/getting_ospray.html</a> (this installs in /opt/local/lib).</li>
+
+<li>Download and unpack embree-2.16.2.x86_64.dmg from <a href="https://embree.github.io/downloads.html">https://embree.github.io/downloads.html</a> (this installs in /opt/local/lib).</li>
+
+<li>Download and unpack tbb2017_20170604oss_mac.tgz from <a href="https://github.com/01org/tbb/releases">https://github.com/01org/tbb/releases</a>.  After expanding the .tar, you'll copy the .dylib files to /usr/local/lib (overwritting some).  Why?  The homebrew install for tbb doesn't created the *_debug.dylib's.  One could also just install TBB entirely from the website and skip the homebrew install.</li>
+</ul><br>
+
+After doing so, you'll likely want to make sure that your commandline knows about ospray/embree, the easy fix for this is to add <code>export DYLD_LIBRARY_PATH="/opt/local/lib"</code> to your <code>~/.bashrc</code>.
+</p>
+
+
+
+
+
+
+<p><h3>3. Preparing the sources</h3>
+These instructions are identical.
+</p>
+
+<p><h3>4. Patching the ParaView source tree</h3>
+These instructions are identical.
+</p>
+
+
+
+
+
+
+
+<p><h3>5. Configuring, building and installing ParaView</h3>
+<h4>a) Configuration</h4>
+To enter the configuration menu of ParaView's build, enter the following commands:<br><br>
+<code>$ cd ~/ttk/ParaView-v5.4.0/</code><br>
+<code>$ mkdir build</code><br>
+<code>$ cd build</code><br>
+<code>$ ccmake ..</code> (on OSX there is no <code>cmake-gui</code>)<br><br>
+
+Then, press 'c' to configure and we'll edit some CMake flags:<br><br>
+
+<code>&nbsp;&middot;&nbsp;CMAKE_BUILD_TYPE=Release</code><br>
+<code>&nbsp;&middot;&nbsp;PARAVIEW_ENABLE_PYTHON=ON</code><br>
+<code>&nbsp;&middot;&nbsp;PARAVIEW_INSTALL_DEVELOPMENT_FILES=OFF</code> (this is unused, should be default)<br>
+<code>&nbsp;&middot;&nbsp;PARAVIEW_QT_VERSION=5</code> (Qt4 is deprecated on homebrew, should be default)<br>
+<code>&nbsp;&middot;&nbsp;VTK_RENDERING_BACKEND=OpenGL2</code> (should be default)<br>
+<code>&nbsp;&middot;&nbsp;VTK_SMP_IMPLEMENTATION_TYPE=Sequential</code><br>
+<br>
+
+You can also enable optional pieces, e.g. ffmpeg.  I also had hdf5 installed through homebrew, but I don't think it was necessary to change anything in cmake.<br><br>
+
+Note, if you've correctly installed OSPRay for OSX, you can use the following:<br><br>
+
+<code>&nbsp;&middot;&nbsp;PARAVIEW_USE_OSPRAY=ON</code><br>
+<code>&nbsp;&middot;&nbsp;VTK_SMP_IMPLEMENTATION_TYPE=TBB</code><br>
+<br>
+
+Then, press 'c' to configure (wait a minute) and then press 't' for advanced mode and we'll edit some more CMake flags:<br><br>
+
+<code>&nbsp;&middot;&nbsp;PYTHON_INCLUDE_DIR=/usr/local/Frameworks/Python.framework/Versions/Current/include/python2.7 </code><br>
+<code>&nbsp;&middot;&nbsp;PYTHON_LIBRARY=/usr/local/Frameworks/Python.framework/Versions/Current/lib/libpython2.7.dylib </code><br><br>
+
+And if you're doing the optional OSPRay build, also set:<br><br>
+
+<code>&nbsp;&middot;&nbsp;OSPRAY_INSTALL_DIR=/opt/local/lib</code><br>
+<br>
+
+
+Press 'c' again, which fills in some more paths, and then press 'c' one more time and things should be ready to press 'g' to generate and exit.<br><br>
+
+
+<h4>b) Build</h4>
+Now you can start the compilation process by entering the following command, where <code>N</code> is the number of available cores on your system (this will take a <b>LONG</b> time):<br><br>
+<code>$ make -jN</code><br><br>
+
+<h4>c) Installation</h4>
+Once the build is finished, we recommend that you do <strong>not</strong> use <code>make install</code>.  We will work directly in the build directory for the source tree instead of trying to package up a MacOS .app file in <code>/Applications</code>.  We'll need to manually make a directory for this:<br><br>
+
+<code>$ mkdir ~/ttk/ParaView-v5.4.0/build/bin/paraview.app/Contents/MacOS/plugins</code><br>
+
+</p>
+
+
+
+<p>
+<h3>6. Configuring, building and installing TTK</h3>
+<h4><a name="ttkConfig">a)</a> Configuration</h4>
+To enter the configuration menu of TTK's build, enter the following commands:<br><br>
+<code>$ cd ~/ttk/ttk-0.9.1/</code><br>
+<code>$ mkdir build</code><br>
+<code>$ cd build</code><br>
+<code>$ ccmake ..</code><br><br>
+
+The configuration window opens.  Press 'c' to configure, and you'll see that it cannot yet find ParaView.  First, we'll fix this:<br><br>
+
+<code>&nbsp;&middot;&nbsp;ParaView_DIR=~/ttk/ParaView-v5.4.0/build/</code><br><br>
+
+Press 'c' again to configure (you can ignore the warnings).  Also note that <code>VTK_DIR</code> should automatically be set to the homebrew installation of VTK (<code>/usr/local/lib/cmake/vtk-7.1</code>).  Next, change:<br><br>
+
+<code>&nbsp;&middot;&nbsp;CMAKE_BUILD_TYPE=Release</code><br>
+<code>&nbsp;&middot;&nbsp;TTK_BINARY_INSTALL_DIR=~/ttk/ttk-0.9.1/bin</code><br>
+<code>&nbsp;&middot;&nbsp;TTK_PLUGIN_INSTALL_DIR=<br>~/ttk/ParaView-v5.4.0/build/bin/paraview.app/Contents/MacOS/plugins"</code><br>
+<code>&nbsp;&middot;&nbsp;withOpenMP=OFF</code><br>
+<br>
+
+Press 'c' to reconfigure (again takes a few seconds) and then press 'g' to generate.<br><br>
+
+<h4>b) Build</h4>
+Now you can start the compilation process by entering the following command, where <code>N</code> is the number of available cores on your system:<br><br>
+<code>$ make -jN</code><br><br>
+
+<h4>c) Installation</h4>
+Once the build is finished, enter the following command to install your build of TTK into your ParaView installation :<br><br>
+<code>$ make install</code><br><br>
+
+Note that, in addition to copying the TTK plugins to your ParaView installation (<code>TTK_PLUGIN_INSTALL_DIR</code>), the above command also installed a collection of standalone TTK programs to <code>TTK_BINARY_INSTALL_DIR</code>.  These can be used outside of ParaView, either as command line tools or VTK-based graphical user interfaces. To list them:<br><br>
+<code>$ ls TTK_BINARY_INSTALL_DIR/*Cmd</code><br>
+<code>$ ls TTK_BINARY_INSTALL_DIR/*Gui</code><br><br>
+Replacing <code>TTK_BINARY_INSTALL_DIR</code> with what we used above.<br><br>
+
+If you wish to disable the build and installation of certain TTK components, just comment the corresponding lines in the <code>CMakeLists.txt</code> file at the root of the source tree (<code>~/ttk/ttk-0.9.1/CMakeLists.txt</code> in our example) prior to entering the configuration step of TTK's build (<a href="#ttkConfig">section 6.a</a>).<br><br>
+
+Finally, to make sure the example data files are included in the right path, you have to manually copy the example data into the ParaView .app as well:<br><br>
+<code>$ cd ~/ttk/ttk-0.9.1/paraview/patch/data</code><br>
+<code>$ mkdir ~/ttk/ParaView-v5.4.0/build/bin/paraview.app/Contents/data</code><br>
+<code>$ cp * ~/ttk/ParaView-v5.4.0/build/bin/paraview.app/Contents/data</code><br>
+<br>
+</p>
+
+
+
+
+<p>
+<h3>7. Checking your TTK installation</h3>
+If you applied all the above steps successfully (including step 4), you can now open a terminal and type the following command to load your TTK-patched ParaView:<br><br>
+<code>$ cd ~/ttk/ParaView-v5.4.0/build/bin/paraview.app/Contents/MacOS/</code><br><br>
+<code>$ ./paraview</code><br><br>
+
+At this point, everything from the standard installation procedure should be accessible.  Congrats!
+</p>
+            </div>
+        </div>
+    </div>
+
+    <hr>
+
+    <!-- Footer -->
+    <footer>
+        <div class="container">
+            <div class="row">
+                <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">
+                    <p class="copyright text-muted">
+                    Contact: <a href="mailto:topology.tool.kit@gmail.com">
+                    topology.tool.kit@gmail.com</a><br>
+                    Updated on May 11th, 2017.</p>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+    <!-- jQuery -->
+    <script src="vendor/jquery/jquery.min.js"></script>
+
+    <!-- Bootstrap Core JavaScript -->
+    <script src="vendor/bootstrap/js/bootstrap.min.js"></script>
+
+    <!-- Contact Form JavaScript -->
+    <script src="js/jqBootstrapValidation.js"></script>
+    <script src="js/contact_me.js"></script>
+
+    <!-- Theme JavaScript -->
+    <script src="js/clean-blog.min.js"></script>
+
+</body>
+
+</html>

--- a/installation-osx.html
+++ b/installation-osx.html
@@ -145,19 +145,36 @@ id="bs-example-navbar-collapse-1">
 Some notes on installation for OSX, using Sierra 10.12.5.  The key differences involve how ParaView is compiled, installing certain dependencies, and setting up some of the paths for OSX.  The follow assumes that the target is to compile with OSX clang and uses homebrew for dependencies.<br>
 
 <p><h3>1. Downloads</h3>
-These instructions are identical.
+Note: The instructions for this step are identical to those on linux:<br><br>
+
+TTK builds on top of <a href="http://www.paraview.org" 
+target="new">ParaView</a> for its main user interface. Thus, you will first 
+need to download 
+<a 
+href="http://www.paraview.org/paraview-downloads/download.php?submit=Download&
+version=v5.4&type=source&os=all&downloadFile=ParaView-v5.4.0.tar.gz" 
+target="new">
+ParaView's source code</a>.
+Note 
+that TTK plugins for ParaView will only work with a version of ParaView 
+compiled from source. Thus, if you already installed ParaView with a binary 
+copy, you may need to un-install it before proceeding.
+                  Next, download TTK from our <a 
+href="downloads.html">download page</a>.
 </p>
 
 
 
 <p><h3>2. Installing the dependencies</h3>
-Using homebrew, install:
+Using <a href="https://brew.sh/">homebrew</a>, install:
 <ul>
 <li> cmake (tested with 3.8.2) </li>
 <li> qt5 (tested with 5.9.0) </li>
 <li> python (tested with 2.7.13) </li>
 <li> vtk (tested with 7.1.1_1) </li>
-</ul><br>
+</ul>
+Using the command: <br><br>
+<code>$ brew install cmake qt5 python vtk</code><br><br>
 
 <h4>a) Optional Dependencies</h4>
 
@@ -167,7 +184,8 @@ Using homebrew, one can install:
 <li> hdf5 (tested with 1.10.1) </li>
 <li> tbb (tested with 2017_U7) -- needed for OSPRay </li>
 <li> mpich (tested with 3.2_3) -- needed for OSPRay's execution </li>
-</ul><br>
+</ul>
+Using the command (or only parts of it): <code>$ brew install ffmpeg hdf5 tbb mpich</code><br><br>
 
 And, in addition, one can install OSPRay and it's dependencies using:
 
@@ -188,11 +206,36 @@ After doing so, you'll likely want to make sure that your commandline knows abou
 
 
 <p><h3>3. Preparing the sources</h3>
-These instructions are identical.
+Note: The instructions for this step are identical to those on linux:<br><br>
+
+Move the tarballs to a working directory (for instance called 
+<code>~/ttk</code>) and decompress them by entering the following commands in 
+a terminal (this assumes that you downloaded the tarballs to the 
+<code>~/Downloads</code> directory):<br><br>
+<code>$ mkdir ~/ttk</code><br>
+<code>$ mv ~/Downloads/ParaView-v5.4.0.tar.gz ~/ttk/</code><br>
+<code>$ mv ~/Downloads/ttk-0.9.2.tar.gz ~/ttk/</code><br>
+<code>$ cd ~/ttk</code><br>
+<code>$ tar xvzf ParaView-v5.4.0.tar.gz</code><br>
+<code>$ tar xvzf ttk-0.9.2.tar.gz</code><br><br>
+You can delete the tarballs after the source trees have been decompressed by 
+entering the following commands:<br><br>
+<code>$ rm ParaView-v5.4.0.tar.gz</code><br>
+<code>$ rm ttk-0.9.2.tar.gz</code><br><br>
 </p>
 
 <p><h3>4. Patching the ParaView source tree</h3>
-These instructions are identical.
+Note: The instructions for this step are identical to those on linux:<br><br>
+
+In order to enjoy the complete set of TTK features, we 
+recommend at this stage to patch the ParaView source tree. 
+This step is 
+optional. 
+To proceed, go to 
+the patch directory and apply it as follows:<br><br>
+<code>$ cd ~/ttk/ttk-0.9.2/paraview/patch</code><br>
+<code>$ ./patch-paraview-5.4.0.sh
+ ~/ttk/ParaView-v5.4.0/</code><br><br>
 </p>
 
 
@@ -258,7 +301,7 @@ Once the build is finished, we recommend that you do <strong>not</strong> use <c
 <h3>6. Configuring, building and installing TTK</h3>
 <h4><a name="ttkConfig">a)</a> Configuration</h4>
 To enter the configuration menu of TTK's build, enter the following commands:<br><br>
-<code>$ cd ~/ttk/ttk-0.9.1/</code><br>
+<code>$ cd ~/ttk/ttk-0.9.2/</code><br>
 <code>$ mkdir build</code><br>
 <code>$ cd build</code><br>
 <code>$ ccmake ..</code><br><br>
@@ -270,7 +313,7 @@ The configuration window opens.  Press 'c' to configure, and you'll see that it 
 Press 'c' again to configure (you can ignore the warnings).  Also note that <code>VTK_DIR</code> should automatically be set to the homebrew installation of VTK (<code>/usr/local/lib/cmake/vtk-7.1</code>).  Next, change:<br><br>
 
 <code>&nbsp;&middot;&nbsp;CMAKE_BUILD_TYPE=Release</code><br>
-<code>&nbsp;&middot;&nbsp;TTK_BINARY_INSTALL_DIR=~/ttk/ttk-0.9.1/bin</code><br>
+<code>&nbsp;&middot;&nbsp;TTK_BINARY_INSTALL_DIR=~/ttk/ttk-0.9.2/bin</code><br>
 <code>&nbsp;&middot;&nbsp;TTK_PLUGIN_INSTALL_DIR=<br>~/ttk/ParaView-v5.4.0/build/bin/paraview.app/Contents/MacOS/plugins"</code><br>
 <code>&nbsp;&middot;&nbsp;withOpenMP=OFF</code><br>
 <br>
@@ -290,10 +333,10 @@ Note that, in addition to copying the TTK plugins to your ParaView installation 
 <code>$ ls TTK_BINARY_INSTALL_DIR/*Gui</code><br><br>
 Replacing <code>TTK_BINARY_INSTALL_DIR</code> with what we used above.<br><br>
 
-If you wish to disable the build and installation of certain TTK components, just comment the corresponding lines in the <code>CMakeLists.txt</code> file at the root of the source tree (<code>~/ttk/ttk-0.9.1/CMakeLists.txt</code> in our example) prior to entering the configuration step of TTK's build (<a href="#ttkConfig">section 6.a</a>).<br><br>
+If you wish to disable the build and installation of certain TTK components, just comment the corresponding lines in the <code>CMakeLists.txt</code> file at the root of the source tree (<code>~/ttk/ttk-0.9.2/CMakeLists.txt</code> in our example) prior to entering the configuration step of TTK's build (<a href="#ttkConfig">section 6.a</a>).<br><br>
 
 Finally, to make sure the example data files are included in the right path, you have to manually copy the example data into the ParaView .app as well:<br><br>
-<code>$ cd ~/ttk/ttk-0.9.1/paraview/patch/data</code><br>
+<code>$ cd ~/ttk/ttk-0.9.2/paraview/patch/data</code><br>
 <code>$ mkdir ~/ttk/ParaView-v5.4.0/build/bin/paraview.app/Contents/data</code><br>
 <code>$ cp * ~/ttk/ParaView-v5.4.0/build/bin/paraview.app/Contents/data</code><br>
 <br>
@@ -324,7 +367,7 @@ At this point, everything from the standard installation procedure should be acc
                     <p class="copyright text-muted">
                     Contact: <a href="mailto:topology.tool.kit@gmail.com">
                     topology.tool.kit@gmail.com</a><br>
-                    Updated on May 11th, 2017.</p>
+                    Updated on June 26, 2017.</p>
                 </div>
             </div>
         </div>

--- a/installation.html
+++ b/installation.html
@@ -150,8 +150,8 @@ href="http://releases.ubuntu.com/17.04/ubuntu-17.04-desktop-amd64.iso"
 target="new">
 Ubuntu Linux 17.04</a> operating system (but the process should be very similar 
 for other Linux distributions). 
-TTK is also supported  on 
-MacOS. Successful ports to Microsoft Windows have been reported.
+TTK is also <a href="installation-osx.html">supported  on 
+MacOS</a>. Successful ports to Microsoft Windows have been reported.
 <br><a href="tutorials.html#installation" target="new">A video from our 
 tutorial page</a> 
 also shows how to proceed on a step-by-step basis.<br> <br>


### PR DESCRIPTION
I've written up some of the instructions for compiling on OSX Sierra 10.12.5

Note that these were tested with ParaView 5.4.0 (and thus require the patch for that), but they are otherwise identical to ParaView 5.3.0.