### PR TITLE
[MergeTree*] update doc links

### DIFF
--- a/doc/html/classttkBlockAggregator.html
+++ b/doc/html/classttkBlockAggregator.html
@@ -291,6 +291,13 @@ Additional Inherited Members</h2></td></tr>
   </table>
   </dd>
 </dl>
+
+<p><b>Online</b> <b>examples:</b> <br  />
+</p><ul>
+<li><a href="https://topology-tool-kit.github.io/examples/mergeTreeClustering/">Merge Tree Clustering example</a> <br  />
+</li>
+</ul>
+
 <dl class="section see"><dt>See also</dt><dd><a class="el" href="classttkAlgorithm.html" title="Baseclass of all VTK filters that wrap ttk modules.">ttkAlgorithm</a> </dd></dl>
 
 <p class="definition">Definition at line <a class="el" href="ttkBlockAggregator_8h_source.html#l00027">27</a> of file <a class="el" href="ttkBlockAggregator_8h_source.html">ttkBlockAggregator.h</a>.</p>

--- a/doc/html/classttkCinemaProductReader.html
+++ b/doc/html/classttkCinemaProductReader.html
@@ -295,6 +295,10 @@ Additional Inherited Members</h2></td></tr>
 </p><ul>
 <li><a href="https://topology-tool-kit.github.io/examples/cinemaIO/">Cinema IO example</a> <br  />
  </li>
+<li><a href="https://topology-tool-kit.github.io/examples/mergeTreeClustering/">Merge Tree Clustering example</a> <br  />
+</li>
+<li><a href="https://topology-tool-kit.github.io/examples/mergeTreeTemporalReduction/">Merge Tree Temporal Reduction</a> <br  />
+</li>
 </ul>
 
 <p class="definition">Definition at line <a class="el" href="ttkCinemaProductReader_8h_source.html#l00037">37</a> of file <a class="el" href="ttkCinemaProductReader_8h_source.html">ttkCinemaProductReader.h</a>.</p>

--- a/doc/html/classttkCinemaReader.html
+++ b/doc/html/classttkCinemaReader.html
@@ -292,6 +292,14 @@ Additional Inherited Members</h2></td></tr>
   </dd>
 </dl>
 
+<p><b>Online</b> <b>examples:</b> <br  />
+</p><ul>
+<li><a href="https://topology-tool-kit.github.io/examples/mergeTreeClustering/">Merge Tree Clustering example</a> <br  />
+</li>
+<li><a href="https://topology-tool-kit.github.io/examples/mergeTreeTemporalReduction/">Merge Tree Temporal Reduction</a> <br  />
+</li>
+</ul>
+
 <p class="definition">Definition at line <a class="el" href="ttkCinemaReader_8h_source.html#l00027">27</a> of file <a class="el" href="ttkCinemaReader_8h_source.html">ttkCinemaReader.h</a>.</p>
 </div><h2 class="groupheader">Member Typedef Documentation</h2>
 <a id="a926b5afc7cb5d4e9712769f2a649928b" name="a926b5afc7cb5d4e9712769f2a649928b"></a>

--- a/doc/html/classttkFTMTree.html
+++ b/doc/html/classttkFTMTree.html
@@ -364,7 +364,6 @@ IEEE Transactions on Parallel and Distributed Systems, Volume 30, Issue 8, Pages
 </li>
 <li><a href="https://topology-tool-kit.github.io/examples/dragon/">Dragon example</a></li>
 <li><a href="https://topology-tool-kit.github.io/examples/mergeTreeClustering/">Merge Tree Clustering example</a> <br  />
- example <br  />
 </li>
 <li><a href="https://topology-tool-kit.github.io/examples/mergeTreeTemporalReduction/">Merge Tree Temporal Reduction</a> <br  />
 </li>

--- a/doc/html/classttkFlattenMultiBlock.html
+++ b/doc/html/classttkFlattenMultiBlock.html
@@ -284,6 +284,12 @@ Additional Inherited Members</h2></td></tr>
       </table>
 </div><div class="memdoc">
 
+<p><b>Online</b> <b>examples:</b> <br  />
+</p><ul>
+<li><a href="https://topology-tool-kit.github.io/examples/mergeTreeClustering/">Merge Tree Clustering example</a> <br  />
+</li>
+</ul>
+
 <p class="definition">Definition at line <a class="el" href="ttkFlattenMultiBlock_8h_source.html#l00020">20</a> of file <a class="el" href="ttkFlattenMultiBlock_8h_source.html">ttkFlattenMultiBlock.h</a>.</p>
 
 </div>

--- a/examples/mergeTreeClustering/index.html
+++ b/examples/mergeTreeClustering/index.html
@@ -1262,7 +1262,6 @@ Then, the <a href="https://topology-tool-kit.github.io/doc/html/classttkFTMTree.
 <p><a href="https://topology-tool-kit.github.io/doc/html/classttkDimensionReduction.html">DimensionReduction</a></p>
 <p><a href="https://topology-tool-kit.github.io/doc/html/classttkFlattenMultiBlock.html">FlattenMultiBlock</a></p>
 <p><a href="https://topology-tool-kit.github.io/doc/html/classttkFTMTree.html">FTMTree</a></p>
-<p><a href="https://topology-tool-kit.github.io/doc/html/classttkMergeTreeDistanceMatrix.html">MergeTreeDistanceMatrix</a></p>
 <p><a href="https://topology-tool-kit.github.io/doc/html/classttkMergeTreeClustering.html">MergeTreeClustering</a></p>
 <p><a href="https://topology-tool-kit.github.io/doc/html/classttkMergeTreeDistanceMatrix.html">MergeTreeDistanceMatrix</a></p>
 


### PR DESCRIPTION
This PR modifies the doc of TTK filters used by Merge Tree related filters by adding links to them.